### PR TITLE
Fix for color_temp_kelvin changes made to HAOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🍄 Mushroom (--Better-Sliders)
+# 🍄 Mushroom (--Better-Sliders) 
 
 <!-- [![hacs][hacs-badge]][hacs-url]
 [![release][release-badge]][release-url]
@@ -10,6 +10,8 @@
 ![Overview](https://raw.githubusercontent.com/phischdev/lovelace-mushroom-better-sliders/master/.github/images/readme_image.png)
 
 ## What is mushroom-better-sliders?
+### This is a fix for colour temperature control which was a breaking change in HAOS a while back
+
 This is a fork of the fantastic [Mushrooms UI Cards][original-repo] by piitaya, a collection of cards for [Home Assistant][home-assistant] Dashboard UI.
 
 > :warning: **This mod will not work, if you still have the original Mushroom installed**

--- a/src/cards/light-card/controls/light-color-temp-control.ts
+++ b/src/cards/light-card/controls/light-color-temp-control.ts
@@ -15,7 +15,7 @@ export class LightColorTempControl extends LitElement {
 
         this.hass.callService("light", "turn_on", {
             entity_id: this.entity.entity_id,
-            color_temp: value,
+            color_temp_kelvin: value,
         });
     }
 
@@ -27,8 +27,8 @@ export class LightColorTempControl extends LitElement {
                 .value=${colorTemp}
                 .disabled=${!isAvailable(this.entity)}
                 .inactive=${!isActive(this.entity)}
-                .min=${this.entity.attributes.min_mireds ?? 0}
-                .max=${this.entity.attributes.max_mireds ?? 100}
+                .min=${this.entity.attributes.min_color_temp_kelvin ?? 2000}
+                .max=${this.entity.attributes.max_color_temp_kelvin ?? 6500}
                 .showIndicator=${true}
                 @change=${this.onChange}
             />
@@ -38,7 +38,7 @@ export class LightColorTempControl extends LitElement {
     static get styles(): CSSResultGroup {
         return css`
             mushroom-slider {
-                --gradient: -webkit-linear-gradient(right, rgb(255, 160, 0) 0%, white 100%);
+                --gradient: -webkit-linear-gradient(right, white 0%, rgb(255, 160, 0) 100%);
             }
         `;
     }

--- a/src/cards/light-card/utils.ts
+++ b/src/cards/light-card/utils.ts
@@ -8,9 +8,13 @@ export function getBrightness(entity: LightEntity): number | undefined {
 }
 
 export function getColorTemp(entity: LightEntity): number | undefined {
-    return entity.attributes.color_temp != null
-        ? Math.round(entity.attributes.color_temp)
-        : undefined;
+    if (entity.attributes.color_temp_kelvin != null) {
+        return Math.round(entity.attributes.color_temp_kelvin);
+    }
+    if (entity.attributes.color_temp != null) {
+        return Math.round(1_000_000 / entity.attributes.color_temp);
+    }
+    return undefined;
 }
 
 export function getRGBColor(entity: LightEntity): number[] | undefined {


### PR DESCRIPTION
## Description

Fixes error message "Failed to perform the action light/turn_on. extra keys not allowed @ data['color_temp']" when trying to adjust the color temperature of a light.

This fix is based on "phischdev/lovelace-mushroom-better-sliders" and not the original project "piitaya/lovelace-mushroom"

## Related Issue
(https://github.com/phischdev/lovelace-mushroom-better-sliders/issues/17)

This PR fixes or closes issue: fixes #

## Motivation and Context

HAOS made changes to how color temperature is controlled. Without this fix, the functionality is broken.

## How Has This Been Tested

Installed the corrected files and rebuilt mushroom.js. Replaced mushroom.js in my own HAOS instance and confirmed it is now working with no error message.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
